### PR TITLE
Fix duplication of sub-types in site types legend

### DIFF
--- a/website/views/sequence.py
+++ b/website/views/sequence.py
@@ -168,8 +168,8 @@ def site_types_hierarchy(include_multi_ptm=True):
 
     available_types.extend(SiteType.available_types())
 
-    sub_types = {
-        sub_type
+    sub_type_names = {
+        sub_type.name
         for site_type in available_types
         for sub_type in site_type.sub_types
     }
@@ -190,7 +190,11 @@ def site_types_hierarchy(include_multi_ptm=True):
     without_subtypes = {
         site_type.name: []
         for site_type in available_types
-        if site_type.name not in with_subtypes and site_type not in sub_types
+        if (
+            site_type.name not in with_subtypes
+            and
+            site_type.name not in sub_type_names
+        )
     }
 
     return {


### PR DESCRIPTION
Expected:

![Screenshot from 2022-02-05 22-50-56](https://user-images.githubusercontent.com/5832902/152661590-3237fc61-6f55-4634-a26b-d3e5de9bdd32.png)

It looks like comparison by instance identity sometimes may not work, so checking names instead.