### PR TITLE
Remove rpy2-pandas version compatibility workaround

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -82,11 +82,6 @@ def create_app(config_filename='config.py', config_override={}):
         base = importr('base')
         base._libPaths(r_library_path)
 
-    # monkey-patch pandas for rpy2 compatibility
-    # TODO: remove this monkey-patch after updating pandas
-    import pandas
-    pandas.NA = object()
-
     # Scheduler
     if app.config.get('SCHEDULER_ENABLED', True):
         if scheduler.running:


### PR DESCRIPTION
Follow up on pandas version upgrade (https://github.com/reimandlab/ActiveDriverDB/pull/175), related to upstream compatibility issue https://github.com/rpy2/rpy2/issues/713