### PR TITLE
Select the less significant call in case of duplicate HIV calls

### DIFF
--- a/website/imports/sites/infections.py
+++ b/website/imports/sites/infections.py
@@ -441,6 +441,15 @@ class HIVPhosphoImporter(
             'Log2 (fold change)  HIV WT vs Mock': 'effect_size'
         }, inplace=True)
 
+        # some combinations of PTMs were called multiple times for a single peptide;
+        # as we have no way to select the most likely call, we conservatively choose
+        # the one which has the least significant results (to avoid inflating FDR)
+        sites = (
+            sites
+            .sort_values('adj_p_val', ascending=False)
+            .drop_duplicates(subset=['protein_accession', 'residue', 'position'], keep='first')
+        )
+
         mapped_sites = self.process_event_associated_sites(
             sites,
             canonical=CANONICAL_PHOSPHOSITE_RESIDUES


### PR DESCRIPTION
Similar to #178 but for HIV and using a different priortization. As seen on the attached screenshot:

![Screenshot from 2022-02-06 21-06-59](https://user-images.githubusercontent.com/5832902/152701339-aa976ab0-dac9-4a86-8386-ac03c0403848.png)

some peptides result in identical PTM calls with different statistics provided (row 44 and 45). As we do not know which call is more likely to be correct, we can choose the more conservative one (the one with a higher p-value) to avoid too many false discoveries.

For some analyses a better approach would be to test both separately and compare the results, but it is not feasible to check all combinations in a sensitivity analysis, nor to import all combinations to the database without reworking the schema, so I suggest to take the path of being on the more cautious side and possibly systematically under-estimating the effects.